### PR TITLE
Detect repo path from script location in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-REPO_DIR="$HOME/personal-setup"
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "=== Personal Setup Installer ==="
 echo "Repo: $REPO_DIR"


### PR DESCRIPTION
## Summary
- `install.sh` hardcoded `REPO_DIR="$HOME/personal-setup"`, which silently skipped every `link_file` when the repo was cloned anywhere else (e.g. `~/dev/personal-setup`).
- Resolve `REPO_DIR` from the script's own location instead, so the installer works regardless of where the repo lives.

## Test plan
- [ ] Merge
- [ ] `cd ~/dev/personal-setup && git pull && ./install.sh`
- [ ] `readlink ~/.claude/CLAUDE.md` points at the repo's `claude/CLAUDE.md`
- [ ] `readlink ~/.zshrc` and `~/.profile` point at the repo copies

🤖 Generated with [Claude Code](https://claude.com/claude-code)