### PR TITLE
Richer zsh prompt, cw worktree helper, slim .profile

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,50 +1,6 @@
-# Git branch in prompt.
+# .profile - login shell config
+# Main config lives in .zshrc; this file handles login-only PATH additions.
 
-parse_git_branch() {
-  git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
-}
-
-location="Dojo"
-PS1='\[\e]0;\w\a\]\n\[\e[34m\]Work Hoodie @ ${location} \[\e[33m\][\d \T]\e[95m\]$(parse_git_branch) \[\e[36m\]\w \[\e[1;96m\]\n🍺 \[\e[0;0m\] '
-alias grep='grep --color'                     # show differences in colour
-# Directory navigation aliases
-alias ..='cd ..'
-alias ...='cd ../..'
-alias ....='cd ../../..'
-alias .....='cd ../../../..'
-#copy and go to dir
-cpg (){
-  if [ -d "$2" ];then
-    cp $1 $2 && cd $2
-  else
-    cp $1 $2
-  fi
-}
-#move and go to dir
-mvg (){
-  if [ -d "$2" ];then
-    mv $1 $2 && cd $2
-  else
-    mv $1 $2
-  fi
-}
-### Docker status server
-dhttp() {
-    while true; do {
-        echo -e 'HTTP/1.1 200 OK\r\n'
-        docker images
-    } | nc -l 8080; done
-}
-
-# Setting PATH for Python 3.5
-# The orginal version is saved in .profile.pysave
-PATH="/Library/Frameworks/Python.framework/Versions/3.5/bin:${PATH}"
-export PATH
-# Setting PATH for Python 3.5
-# The orginal version is saved in .profile.pysave
-PATH="/Library/Frameworks/Python.framework/Versions/3.5/bin:${PATH}"
-export PATH
-# Setting PATH for Python 3.5
-# The orginal version is saved in .profile.pysave
+# Python
 PATH="/Library/Frameworks/Python.framework/Versions/3.5/bin:${PATH}"
 export PATH

--- a/.zshrc
+++ b/.zshrc
@@ -3,31 +3,138 @@
 # =============================================================================
 
 # =============================================================================
-# Prompt Configuration
+# Prompt
 # =============================================================================
-autoload -Uz vcs_info
-precmd() { vcs_info }
+zmodload zsh/datetime
 setopt PROMPT_SUBST
 
-# Git info format
-zstyle ':vcs_info:git:*' formats '%F{magenta}%b%f'
-zstyle ':vcs_info:git:*' actionformats '%F{magenta}%b%f|%F{red}%a%f'
+# -- Exec time tracking ------------------------------------------------------
+_prompt_exec_start=0
+_prompt_exec_time=""
 
-# Git dirty/clean indicator
-git_status() {
-    if git rev-parse --git-dir > /dev/null 2>&1; then
-        if [[ -n $(git status --porcelain 2>/dev/null) ]]; then
-            echo "%F{yellow}*%f"
-        else
-            echo "%F{green}✓%f"
-        fi
-    fi
+_prompt_preexec() {
+  _prompt_exec_start=$EPOCHSECONDS
 }
 
-# Prompt: time | directory | git branch + status
-# Arrow is green on success, red on error
-PROMPT='%F{8}%T%f %F{cyan}%~%f ${vcs_info_msg_0_}$(git_status)
-%(?.%F{cyan}.%F{red})❯%f '
+_prompt_precmd_timer() {
+  if (( _prompt_exec_start == 0 )); then
+    _prompt_exec_time=""
+    return
+  fi
+  local elapsed=$(( EPOCHSECONDS - _prompt_exec_start ))
+  _prompt_exec_start=0
+  if (( elapsed < 5 )); then
+    _prompt_exec_time=""
+    return
+  fi
+  local hours=$(( elapsed / 3600 ))
+  local mins=$(( (elapsed % 3600) / 60 ))
+  local secs=$(( elapsed % 60 ))
+  if (( hours > 0 )); then
+    _prompt_exec_time="${hours}h ${mins}m ${secs}s"
+  elif (( mins > 0 )); then
+    _prompt_exec_time="${mins}m ${secs}s"
+  else
+    _prompt_exec_time="${secs}s"
+  fi
+}
+
+# -- Git info -----------------------------------------------------------------
+_prompt_git_info() {
+  # Bail early if not in a git repo
+  local git_dir
+  git_dir=$(command git rev-parse --git-dir 2>/dev/null) || return
+
+  local branch="" ahead=0 behind=0
+  local staged=0 unstaged=0 untracked=0 conflicts=0
+  local line xy
+
+  # Single call for branch + file status
+  while IFS= read -r line; do
+    case "$line" in
+      "# branch.head "*)
+        branch="${line#\# branch.head }"
+        ;;
+      "# branch.ab "*)
+        ahead="${line#\# branch.ab }"
+        ahead="${ahead%% *}"
+        ahead="${ahead#+}"
+        behind="${line##* }"
+        behind="${behind#-}"
+        ;;
+      "1 "*|"2 "*)
+        xy="${line:2:2}"
+        [[ "${xy[1]}" != "." ]] && (( staged++ ))
+        [[ "${xy[2]}" != "." ]] && (( unstaged++ ))
+        ;;
+      "u "*)
+        (( conflicts++ ))
+        ;;
+      "? "*)
+        (( untracked++ ))
+        ;;
+    esac
+  done < <(command git status --porcelain=v2 --branch 2>/dev/null)
+
+  # Detached HEAD
+  if [[ "$branch" == "(detached)" ]]; then
+    branch=$(command git describe --tags --short --always 2>/dev/null)
+    branch=":${branch}"
+  fi
+
+  # Stash count
+  local stash=0
+  stash=$(command git stash list 2>/dev/null | wc -l | tr -d ' ')
+
+  # Rebase/merge/cherry-pick/bisect state
+  local state=""
+  if [[ -d "$git_dir/rebase-merge" || -d "$git_dir/rebase-apply" ]]; then
+    state="|REBASE"
+  elif [[ -f "$git_dir/MERGE_HEAD" ]]; then
+    state="|MERGE"
+  elif [[ -f "$git_dir/CHERRY_PICK_HEAD" ]]; then
+    state="|PICK"
+  elif [[ -f "$git_dir/BISECT_LOG" ]]; then
+    state="|BISECT"
+  fi
+
+  # Build output
+  local info=""
+  info+="%F{240} on %f"
+  info+="%F{180}${branch}${state}%f"
+  (( staged > 0 ))    && info+=" %F{114}+${staged}%f"
+  (( unstaged > 0 ))  && info+=" %F{216}~${unstaged}%f"
+  (( untracked > 0 )) && info+=" %F{174}?${untracked}%f"
+  (( conflicts > 0 )) && info+=" %F{167}!${conflicts}%f"
+  (( ahead > 0 ))     && info+=" %F{114}↑${ahead}%f"
+  (( behind > 0 ))    && info+=" %F{216}↓${behind}%f"
+  (( stash > 0 ))     && info+=" %F{139}≡${stash}%f"
+
+  echo -n "$info"
+}
+
+# -- Assemble prompt ----------------------------------------------------------
+_prompt_precmd() {
+  local top=""
+
+  # Exec time (if any)
+  if [[ -n "$_prompt_exec_time" ]]; then
+    top+="%F{244}${_prompt_exec_time}%f "
+  fi
+
+  # CWD
+  top+="%F{110}%~%f"
+
+  # Git info
+  top+='$(_prompt_git_info)'
+
+  # Two-line prompt
+  PROMPT="${top}"$'\n'"%(?.%F{114}.%F{167})❱%f "
+}
+
+# -- Register hooks -----------------------------------------------------------
+precmd_functions+=(_prompt_precmd_timer _prompt_precmd)
+preexec_functions+=(_prompt_preexec)
 
 # =============================================================================
 # Aliases
@@ -64,6 +171,78 @@ dhttp() {
         echo -e 'HTTP/1.1 200 OK\r\n'
         docker images
     } | nc -l 8080; done
+}
+
+# =============================================================================
+# Claude Worktree Helper
+# =============================================================================
+# cw <branch>        — open Claude in a worktree for an existing branch
+# cw -n <name>       — create new branch from develop, open Claude
+# cw -l              — list worktrees
+# cw -c              — prune dead worktrees
+cw() {
+  local repo_root
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "error: not in a git repo" >&2; return 1
+  }
+  local wt_dir="${repo_root}/.claude/worktrees"
+
+  case "${1:-}" in
+    -l)
+      git worktree list
+      ;;
+    -c)
+      git worktree prune -v
+      ;;
+    -n)
+      [[ -z "${2:-}" ]] && { echo "usage: cw -n <name>" >&2; return 1; }
+      local name="$2"
+      mkdir -p "$wt_dir"
+      git worktree add "$wt_dir/$name" -b "$name" origin/develop
+      (cd "$wt_dir/$name" && claude)
+      ;;
+    "")
+      echo "usage: cw <branch> | cw -n <name> | cw -l | cw -c" >&2
+      echo "" >&2
+      echo "branches:" >&2
+      git branch --format='  %(refname:short)' | grep -v '^  worktree-' >&2
+      ;;
+    *)
+      local branch="$1"
+      local safe_name="${branch//\//-}"
+      # Verify branch exists (local or remote)
+      local is_remote=false
+      if ! git rev-parse --verify "$branch" &>/dev/null; then
+        if git rev-parse --verify "origin/$branch" &>/dev/null; then
+          is_remote=true
+        else
+          echo "error: branch '$branch' not found (checked local and origin)" >&2
+          echo "local branches:" >&2
+          git branch --format='  %(refname:short)' | grep -v '^  worktree-' >&2
+          return 1
+        fi
+      fi
+      # Check if worktree already exists for this branch
+      local existing
+      existing=$(git worktree list --porcelain | awk -v b="$branch" '
+        /^worktree / { wt=$2 }
+        /^branch / && $2 == "refs/heads/" b { print wt; exit }
+      ')
+      if [[ -n "$existing" ]]; then
+        echo "worktree already exists at $existing"
+        (cd "$existing" && claude)
+      else
+        mkdir -p "$wt_dir"
+        if $is_remote; then
+          # Create local tracking branch in the worktree
+          git worktree add -b "$branch" "$wt_dir/$safe_name" "origin/$branch"
+        else
+          git worktree add "$wt_dir/$safe_name" "$branch"
+        fi
+        (cd "$wt_dir/$safe_name" && claude)
+      fi
+      ;;
+  esac
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary
Replaces the `vcs_info` prompt landed in #2 with a more featureful hand-rolled prompt, adds a `cw` Claude-worktree helper, and trims `.profile` down to login-only PATH.

### `.zshrc`
- Two-line prompt: `cwd  on branch +staged ~unstaged ?untracked !conflicts ↑ahead ↓behind ≡stash` / `❱`
- Driven by a single `git status --porcelain=v2 --branch` call
- Shows in-progress state (`|REBASE`, `|MERGE`, `|PICK`, `|BISECT`)
- Tracks command exec time and surfaces it when >5s
- New `cw` helper:
  - `cw <branch>` — open Claude in a worktree for an existing branch (local or `origin/<branch>`)
  - `cw -n <name>` — create new branch off `origin/develop`, open Claude
  - `cw -l` / `cw -c` — list / prune worktrees
  - Worktrees land under `<repo>/.claude/worktrees/`

### `.profile`
- Strips legacy bash `PS1`, `parse_git_branch`, alias block, `cpg` / `mvg` / `dhttp` helpers, and three duplicated Python 3.5 PATH lines.
- Keeps a single Python PATH export.

## Test plan
- [x] `zsh -n .zshrc` passes
- [x] `bash -n .profile` passes
- [ ] Merge
- [ ] `cd ~/dev/personal-setup && git pull` — symlinks already point at repo, so prompt updates on next `source ~/.zshrc`
- [ ] `cw -l` runs without error in a git repo
- [ ] `git stash drop` to clear the now-redundant pre-install stash

🤖 Generated with [Claude Code](https://claude.com/claude-code)