### PR TITLE
Add email-optimizer and about-page-optimizer skills

### DIFF
--- a/claude/skills/about-page-optimizer/README.md
+++ b/claude/skills/about-page-optimizer/README.md
@@ -1,0 +1,56 @@
+# About Page Optimizer Skill
+
+Expert system for writing an About page that converts — distilled from the Pip Decks *Million Dollar About Page* methodology. A sibling to the `landing-page-optimizer` skill.
+
+## Overview
+
+Turns an About page from a résumé or company-history dump into a conversion tool that builds know-like-trust. Triggered automatically when Claude detects About-page-related keywords.
+
+## Automatic Triggers
+
+The skill activates on terms like: about page, about us, our story, founder story, founder bio, personal brand, know like trust, brand story, meet the team, my story.
+
+## Core Methodology
+
+**The reframe:** the About page is a conversion powerhouse, and it must be about the *customer*, not just you. Goal = connection, not comprehensiveness.
+
+**The Story Mirror Framework (8 sections):** Human connection → Problem recognition → Transformation moment → Journey to solution → Guide positioning → Proof of impact → Human dimension → Call to action. The customer is the hero; you're the guide ("You're not Luke Skywalker, you're Yoda").
+
+**The 5-pass trust checklist:** strip self-promotion → authenticity → tighten (~500 words) → readability → connection (the cocktail-party test).
+
+## Structure
+
+```
+about-page-optimizer/
+├── SKILL.md    # Story Mirror framework + trust checklist + anti-patterns
+└── README.md   # This file
+```
+
+Single-file skill — the methodology is compact enough to keep in one place.
+
+## Capabilities
+
+- Full About page in the 8-section Story Mirror sequence
+- Rewrite of an existing About page (failure mode named)
+- Section-by-section audit against the framework
+- A trust-checklist edit pass on a user's draft
+
+## Example Prompts
+
+- "Help me write my About page"
+- "My About page is just a list of my credentials — fix it"
+- "Audit the About page copy on my site"
+- "Rewrite this founder bio so it connects with customers"
+
+## Installation
+
+Version-controlled in this repo under `claude/skills/about-page-optimizer/` and symlinked into `~/.claude/skills/` by `install.sh`.
+
+## Related skills
+
+- `landing-page-optimizer` — page-copy sibling for landing pages.
+- `email-optimizer` — same storytelling principles applied to email.
+
+## License
+
+Private skill — methodology adapted from Pip Decks *Million Dollar About Page* for personal use.

--- a/claude/skills/about-page-optimizer/SKILL.md
+++ b/claude/skills/about-page-optimizer/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: about-page-optimizer
+description: |
+  About page copywriting expert based on the Million Dollar About Page methodology. Use when helping users write or improve an About page, About Us section, founder story, personal-brand bio, or any "our story" page — turning it from a résumé into a conversion tool that builds know-like-trust. Sibling to the landing-page-optimizer skill.
+  MANDATORY TRIGGERS: about page, about us, our story, founder story, founder bio, personal brand, know like trust, brand story, meet the team, my story
+---
+
+# About Page Optimizer
+
+Expert system for writing an About page that converts — based on the Pip Decks *Million Dollar About Page* methodology.
+
+## The core reframe
+
+Your About page is one of your most-visited pages, and it's a **conversion powerhouse** — not a résumé, not a company history. The single biggest fix: **make it about the customer, not just you.** The goal is *connection*, not comprehensiveness — turn strangers into people who **know, like, and trust** you. People hate being sold to, but they love to buy.
+
+The guiding metaphor is the **Story Mirror**: a page where the customer sees *themselves* reflected in your journey — your challenges, aspirations, and values look like theirs.
+
+## Three ways About pages fail (diagnose first)
+
+- **The invisible face** — hides the human. No photos, corporate language, a generic mission statement.
+- **The résumé dump** — a list of credentials with no relevance to the customer.
+- **The self-centred story** — personal stories that never connect back to customer benefit.
+
+## The Story Mirror Framework (8 sections)
+
+Each section has one job in moving the reader from stranger to client. Write them in order.
+
+1. **Human connection** — establish instant rapport.
+   *Formula:* "Hi, I'm [NAME] — [simple descriptor, no jargon]" → 1–2 sentences of background → an everyday example of your expertise.
+   *Rules:* use "I" and "you," never third person; use a real, warm photo (not a stuffy headshot, cartoon, or baby pic).
+
+2. **Problem recognition** — create "Yes, that's me!" moments.
+   *Formula:* the shared situation → the tension/problem → why it matters.
+   *Rules:* specificity + emotional honesty; mirror how clients actually talk about the problem.
+
+3. **Transformation moment** — the catalyst, the moment everything changed.
+   *Formula:* the moment it changed → what you realized → one sensory or emotional detail.
+   *Rules:* show vulnerability; zoom in on a single decisive moment; bring in a guide figure so it doesn't read as self-congratulation.
+
+4. **Journey to solution** — prove expertise through lived experience, not credentials.
+   *Formula:* the actions you took → 1–2 key insights → how those insights changed your approach.
+
+5. **Guide positioning** — you're not the hero, you're the guide.
+   *Formula:* what you now do for others → your approach/method → how your work gives others the same "gift" you received.
+   *Principle:* **"You're not Luke Skywalker, you're Yoda."** The customer is the hero; you are the expert guide.
+
+6. **Proof of impact** — answer the reader's "so what?"
+   *Formula:* briefly state the impact → make it feel achievable for the reader → back it with specific results or social proof.
+   *Rules:* third-party validation beats self-promotion; frame every accomplishment as a client benefit; keep it brief.
+
+7. **Human dimension** — become three-dimensional.
+   One brief, authentic personal detail (a hobby, quirk, or value). People buy from people. Don't try to look cool; keep it short.
+
+8. **Call to action** — a low-commitment next step.
+   Newsletter, free resource, consultation, or social follow — not a hard sales pitch (that belongs on the services page). No pressure; stay conversational.
+
+**Story arc under the hood:** sections 2–4 follow a **Man-in-a-Hole** shape — comfort zone → trigger → crisis → recovery → better place.
+
+## The 5-pass trust checklist (edit in this order)
+
+1. **Strip the self-promotion** — cut selling phrases, product plugs, and superlatives ("best," "leading," "expert"); remove any whiff of desperation.
+2. **Keep it authentic** — swap jargon for everyday language; add specific details (names, places, feelings); include at least one vulnerability or mistake. Test: "Would I actually say this out loud in conversation?"
+3. **Tighten the structure** — each paragraph should lead into the next; cut anything off-message. Aim for **~500 words total**, paragraphs **3–4 sentences max**.
+4. **Refine for readability** — read it aloud and fix every stumble; reduce bold to 1–2 phrases; **eliminate exclamation points** (they weaken trust); kill buzzwords.
+5. **Optimise for connection** — reveal *why* you care, not just what you do; make sure clients see themselves and their desired transformation. Test: the **cocktail-party test** (would this be interesting told in person?).
+
+## Anti-patterns to avoid
+
+- **The credential dump** — opening with certifications and years of experience.
+- **The sales pitch** — pitching your program (it belongs on the services page).
+- **The life story** — autobiography irrelevant to the client.
+- **The generic inspiration** — vague "passionate about unlocking potential" lines.
+- **The corporate speak** — "leverage data-driven methodologies."
+- **The overpromise** — guaranteed/immediate-results claims. Understating usually beats overpromising.
+
+## Deliverables this skill produces
+
+- A full About page drafted in the 8-section Story Mirror sequence
+- A rewrite of an existing About page (with the failure mode named)
+- A section-by-section audit against the framework
+- A trust-checklist edit pass on a draft the user already has
+
+## Related skills
+
+- `landing-page-optimizer` — the page-copy sibling for landing pages.
+- `email-optimizer` — the same Pip Decks "Million Dollar" storytelling principles applied to email.

--- a/claude/skills/email-optimizer/README.md
+++ b/claude/skills/email-optimizer/README.md
@@ -1,0 +1,67 @@
+# Email Optimizer Skill
+
+Expert system for writing marketing emails people actually open, read, and act on — distilled from the Pip Decks *Million Dollar Emails* methodology.
+
+## Overview
+
+This skill provides specialized expertise in email copywriting, subject lines, story-led emails, and diagnosing underperforming campaigns. It's triggered automatically when Claude detects email-related keywords in conversation.
+
+## Automatic Triggers
+
+The skill activates on terms like: email, subject line, preview text, newsletter, email copy, email marketing, open rate, click rate, cold email, email sequence, nurture sequence, broadcast, email CTA, unsubscribe, deliverability, email idea, email teardown.
+
+## Core Methodology
+
+**Give to Get.** You only buy from people you trust, and trust is built by giving before you ask. Be unreasonably generous; aim for ~3–4 value emails per sales ask.
+
+**The three rules:** be useful, be interesting, be entertaining.
+
+**The spine:** Give before you ask → Tell a story → Get it opened.
+
+**The engine — build backwards:** the reader reads Story → Lesson → Ask; you build it Ask → Lesson → Story. Decide the ask first ("By the end of this email I want the reader to ___"), one email/one lesson/one ask, then find the story to land it.
+
+**Get it opened:** subject line + preview text are one hook in two beats — the subject opens a loop, the preview deepens it. ~35 chars, curiosity or lesson-hint, no ALL CAPS / emoji / spam words / AI generators.
+
+## Structure (progressive disclosure)
+
+The core methodology lives in `SKILL.md`; the bulky swipe material is loaded on demand from `references/`:
+
+```
+email-optimizer/
+├── SKILL.md                     # Core methodology + router
+├── README.md                    # This file
+└── references/
+    ├── subject-lines.md         # 12 hook types + subject/preview pairing
+    ├── idea-vault.md            # 50 prompts across 6 sources
+    ├── diagnosis.md             # 4-symptom audit with benchmarks + fixes
+    └── anatomy-examples.md      # 5 annotated real-email teardowns
+```
+
+## Capabilities
+
+- Finished story-led emails built backwards
+- Subject line + preview-text option sets by hook type
+- Idea sprints (ask/lesson/story trios)
+- Diagnoses of underperforming emails/campaigns with prioritized fixes
+- Customer-testimonial interview scripts
+- Before/after rewrites
+
+## Example Prompts
+
+- "Write a launch email for my new course"
+- "Give me 5 subject lines for a re-engagement email"
+- "My open rate dropped to 12% — what's wrong?"
+- "I'm out of newsletter ideas, help me brainstorm"
+- "Rewrite this email to be less salesy"
+
+## Installation
+
+Version-controlled in this repo under `claude/skills/email-optimizer/` and symlinked into `~/.claude/skills/` by `install.sh`.
+
+## Related skills
+
+- `landing-page-optimizer` and `about-page-optimizer` — sibling copy skills from the same Pip Decks "Million Dollar" family.
+
+## License
+
+Private skill — methodology adapted from Pip Decks *Million Dollar Emails* for personal use.

--- a/claude/skills/email-optimizer/SKILL.md
+++ b/claude/skills/email-optimizer/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: email-optimizer
+description: |
+  Email marketing and copywriting expert based on the Million Dollar Emails methodology. Use when helping users write, improve, or audit marketing emails, newsletters, broadcasts, sequences, or cold outreach — including subject lines, preview text, email body copy, calls to action, and story-led emails. Also use to diagnose underperforming emails (low opens/clicks/sales, rising unsubscribes) and to generate email ideas when the user is stuck.
+  MANDATORY TRIGGERS: email, subject line, preview text, newsletter, email copy, email marketing, open rate, click rate, click-through, cold email, email sequence, nurture sequence, broadcast, email CTA, unsubscribe, deliverability, email idea, email teardown
+---
+
+# Email Optimizer
+
+Expert system for writing marketing emails people actually open, read, and act on — distilled from the Pip Decks *Million Dollar Emails* methodology.
+
+The whole philosophy fits in one line: **we only buy from people we trust, and trust is built by giving before you ask.** Every technique below serves that.
+
+## The Give to Get Framework
+
+Your email list is the only audience you truly own (algorithms can vanish overnight). You grow its value by being **unreasonably generous** — giving readers more than they paid for, more than they expected, more than competitors will.
+
+Think of it as a **piggy bank**: every genuinely useful email drops a coin in; a sales ask breaks it open. Ask too early and often and the bank is empty. Aim for roughly **3–4 pure-value emails per 1 sales ask** (the give-to-get ratio).
+
+**The three rules every great email follows** — be **useful**, be **interesting**, be **entertaining**. The best emails hit all three at once. If an email does none, it's the only kind of unsubscribe worth worrying about: one you earned by being boring.
+
+## The spine: three principles
+
+Everything in this skill hangs on three principles (they're also the reading order the *reader* experiences):
+
+1. **Give before you ask** — earn the right to sell.
+2. **Tell a story** — a story lands a lesson in a way a bullet list never will.
+3. **Get it opened** — no open, no anything. Sweat the subject line and preview text.
+
+## The engine: build your email backwards
+
+The reader reads **Story → Lesson → Ask**. You build it in reverse: **Ask → Lesson → Story.** Decide the destination before you write a word.
+
+### 1. The Ask (decide FIRST)
+The reason the email exists. Finish this sentence before writing anything:
+
+> "By the end of this email I want the reader to ______."
+
+If you can't finish it, you don't have an email yet. Rules:
+- **One email, one lesson, one ask.** (The ask may appear twice — body + P.S. — but it's still one ask.)
+- Even a pure content email needs an ask, at minimum a link to somewhere the reader can go next.
+- Make the ask a **follow-on**: the natural next step deeper into the topic you just covered. The closer it sits to what you actually sell, the better.
+
+### 2. The Lesson (decide SECOND)
+One useful sentence the reader remembers. Write it at the top of your draft **in bold**; every line that doesn't serve it gets cut. A good lesson works on **two levels**:
+- Genuinely useful on its own (that's the gift), and
+- A quiet proof of expertise — "if the free stuff is this good, imagine the paid stuff."
+
+If you can't crush it to one sentence, you have two lessons fighting for space. Split them into two emails.
+
+### 3. The Story (find LAST)
+The story earns attention and makes the lesson stick. It should be **roughly two-thirds of the email**; lesson + ask share the final third. (Exception: late-in-a-sale reminder emails shrink or drop the story.)
+
+Two moves that make stories work:
+- **But & Therefore.** Beats joined by "and then" are dead. Join them with **"but"** (an obstacle) or **"therefore"** (a consequence). Borrowed from the *South Park* writers — it's the difference between a list of events and a story.
+- **A-to-B vs. A-to-Z.** A-to-B: the story obviously relates to the lesson (reader sees it coming). **A-to-Z**: the story comes from somewhere unexpected and loops back to the lesson. A-to-Z is more engaging — reach for it.
+
+**Four places stories come from:** (1) personal stories, (2) historical events & case studies, (3) customer stories, (4) your own observations. Keep a running "email fodder" notes file — one standout moment jotted each day becomes a year of emails.
+
+## Get it opened: subject line + preview text
+
+Written **last, read first.** Treat them as **one hook in two beats**:
+- **Subject line** = the first loop — opens a question.
+- **Preview text** = the second loop — deepens the question *without answering it.* Never leave it on the default "Hi {first_name}."
+
+Essentials:
+- **~35 characters** usable on mobile (≈3–7 words). Too long? Cut it, push the rest into preview text, or front-load the most enticing word.
+- Lead with **pure curiosity** (gives nothing away) OR **hint at the lesson** (the value of knowing) — pick whichever is the email's bigger pull.
+- Curiosity is fine *as long as the email cashes the cheque.* Curiosity that doesn't pay off is clickbait, and it poisons trust in every future email.
+- **Don'ts:** ALL CAPS, emojis (now read as "AI slop"), spam-trigger words (free, act now, click here, limited time, 100% guaranteed, buy now), and AI subject-line generators (they can only remix the past — they can't surprise).
+
+The **first line of the body is the second hook** — open a loop immediately. Three ways: ask a question, be specific from the first word (a date/place), or say something surprising. Never open with a polite throat-clear ("Just a quick note…", "Hope you're well…").
+
+## The 5-step implementation roadmap
+
+1. **Decide the ask.** Finish "By the end of this email I want the reader to ___." One verb, one link, one ask. Write it at the top.
+2. **Decide the lesson.** One sentence, the route to the ask, working on both levels. Write it under the ask in bold.
+3. **Find the story.** Pull from the four sources; pick the story that fits the lesson (not your favourite); prefer A-to-Z.
+4. **Craft the email.** Open with a loop; connect beats with but/therefore; be specific and concrete; stay in the action; mix paragraph lengths; end with the lesson (1–2 sentences) then the ask (one clean line). Read it aloud and cut wherever you stumble or start sounding "professional."
+5. **Write subject + preview, then send.** Find the subject line *inside* what you already wrote; make it the two-beat hook; obey the don'ts. Then hit send — you'll never feel ready.
+
+## Voice principles (echo these)
+
+- **The reader is selfish** — assume "nobody cares" and earn attention line by line. Ask of every sentence: "what is this line doing?" If you can't answer, cut it.
+- **Vulnerability builds trust.** Email was made for one human talking to another — write that way even to 200,000 people. Self-doubt is a superpower; the worried writer serves the reader, the arrogant one shows off.
+- **Show, don't say** trust — you can't just write "trust me."
+- **The minute something feels familiar, readers tune out.** Find a fresh angle every time. Steal the *move* behind a good email, never the words.
+- Don't try to sound smart ("We are delighted to announce…"). Nobody talks like that.
+
+**Three reasons emails get ignored:** the *taker* (only ever asks), the *faceless brand* (from a company, not a person), the *boring-as-sin* (no reason to open).
+
+## Router: when to open a reference file
+
+Keep this file as the working core. Read a reference only when the task calls for it:
+
+| The task | Read |
+| --- | --- |
+| Write or choose a **subject line / preview text** | `references/subject-lines.md` (12 hook types + pairing) |
+| **Stuck for what to write** / want an idea sprint | `references/idea-vault.md` (50 prompts, 6 sources) |
+| An email or campaign is **underperforming** (opens/clicks/sales/unsubs) | `references/diagnosis.md` (4-symptom audit + fixes) |
+| Want **worked examples** to model tone & structure | `references/anatomy-examples.md` (5 annotated teardowns) |
+
+## Deliverables this skill produces
+
+- A finished story-led email built backwards (ask → lesson → story)
+- A batch of subject line + preview-text options by hook type
+- An idea sprint (10–30 ask/lesson/story pairs from a 20-minute timer)
+- A diagnosis of an underperforming email or campaign with prioritized fixes
+- A customer-testimonial interview script (Before / During / After / Value) for sourcing story material
+- Before/after rewrites of a user's existing email

--- a/claude/skills/email-optimizer/references/anatomy-examples.md
+++ b/claude/skills/email-optimizer/references/anatomy-examples.md
@@ -1,0 +1,61 @@
+# The Anatomy of a Million Dollar Email — Worked Teardowns
+
+Based on *The Anatomy of a Million Dollar Email* plus swipe emails from the core book. Use these to model tone and structure — study the *move*, don't copy the copy. Open rates are noted to show what each type can do.
+
+## How to read a teardown
+For each email, notice three things: the **type** (what job it does in the campaign), the **ask/lesson/story** split, and the **one technique** it demonstrates. Map that technique back to the SKILL.md engine.
+
+## Table of contents
+- The 5 annotated emails
+- Swipe emails referenced in the core book
+- The customer-interview script (how to source story material)
+
+---
+
+## The 5 annotated emails
+
+### 1. "Make your customers feel like heroes" — 65.2% open
+**Type:** pure story, no sale (soft bracketed CTA at the end).
+**Technique:** *eat your own dog food* — the email uses the exact technique it's teaching. Lesson delivered in three parts: state the principle as a question → break it into numbered sub-lessons → "instead of this / try this" contrast.
+**Take:** a value email can carry a whisper-quiet CTA and still do its job; demonstrating the technique is more convincing than describing it.
+
+### 2. "You're probably underselling yourself right now" — 55.5%
+**Type:** customer-testimonial launch email, done differently.
+**Technique:** narrate the customer's story **in your own voice**, then drop the direct customer quotes underneath as evidence. A P.P.S. calls out the meta-moment (the technique demonstrating itself).
+**Take:** don't paste a testimonial — tell it as a story and use the quote as proof.
+
+### 3. "A lesson from 7 years of business" — 64.7%
+**Type:** short, almost all lesson, no classic story arc.
+**Technique:** vulnerability over expertise; a second-person analogy the reader feels; the CTA lives entirely in the P.S.
+**Take:** you don't always need a story — sometimes honesty and a sharp lesson are the whole email.
+
+### 4. "How to build a cult" — 76.4% (highest)
+**Type:** objection-handling email, sent on the second-to-last day of a sale, disguised inside a bigger argument.
+**Technique (the objection pattern):** for each objection — **name it in the reader's own voice → say why it's wrong → teach the underlying principle → point to a specific named tactic in the product.** CTA leads with "so you can [outcome]" before listing contents. Memorable line: "Branding is the story. Marketing is the megaphone."
+**Take:** this is the template for a sales email that never feels salesy — it teaches while it sells.
+
+### 5. "I hate this marketing advice" — 65.7%
+**Type:** webinar / event announcement.
+**Technique:** keep the teaching light so the event still has value to sell — "leave the inbox slightly hungry." Reframes the assumed solution ("post constantly") as the actual problem.
+**Take:** when the ask is "attend this," don't give away the whole lesson in the email.
+
+---
+
+## Swipe emails referenced in the core book
+
+- **"The $180,000 zine"** — a soft-CTA podcast email; the useful payload is a *diagnostic*; netted ~400 subscribers off nothing but a P.S. mention. Proof that the ask can be tiny and still convert.
+- **"How one story makes $1B a year"** (Febreze) — a textbook A-to-Z story. Lesson: "Logic doesn't move people to buy. A story does." They chose the story because the logical pitch had failed, the story pitch succeeded, the numbers were undeniable, and there was one vivid central scene.
+- **Steve Rawling's One-Sentence Pitch** — lesson: "One clear outcome beats a list of promises." Four tips: start with what changes for the client; steal your clients' language; cut until it hurts; say it out loud.
+
+---
+
+## The customer-interview script (source your story material)
+
+Turn a glowing testimonial into a story by interviewing the customer (15 minutes, offer a thank-you). Four stages:
+
+1. **Before** (set the scene): What was the problem like before? How did you feel? What was the hardest part? What made you reach out?
+2. **During** (the experience): What stood out? Any surprises? What was the biggest "aha" moment? How did you apply it?
+3. **After** (the transformation): What's changed? Describe a specific moment you applied it and the result. What tangible results have you seen?
+4. **Value** (social proof): Who would you recommend us to? What would you say to someone on the fence? Was it worth it? Describe it in one sentence.
+
+Then tell the story **in your own voice**, in whatever shape fits, and use direct customer quotes underneath as evidence.

--- a/claude/skills/email-optimizer/references/diagnosis.md
+++ b/claude/skills/email-optimizer/references/diagnosis.md
@@ -1,0 +1,87 @@
+# The Email Diagnosis Guide — 4 Symptoms and How to Fix Them
+
+Based on the *Email Diagnosis Guide*. Use when an email or campaign underperforms. Each symptom has a **benchmark** (to confirm the problem is real before you act), **root causes**, **fixes**, and a **trap** to avoid.
+
+## Before diagnosing anything: the technical gate
+A brand-new or un-warmed sending domain lands in spam no matter how good the copy. Check deliverability first (e.g. mail-tester.com). If the domain is cold, warm it up — send small batches and get real replies before scaling.
+
+## Table of contents
+1. Low open rates
+2. Low click rates
+3. Low sales
+4. Rising unsubscribes
+
+---
+
+## Symptom 1 — Low open rates
+
+**Benchmark first.** Average opens run 20–25%; >30% is good, >40% excellent. In the 20s? Probably fine — don't fix what isn't broken. Under 15%, or a sharp drop, is a real problem.
+
+**Two root causes:**
+1. Subject lines aren't landing (or misread the audience).
+2. The list has gone stale — unengaged subscribers drag the rate down.
+
+*Minor drags:* wrong send time, a corporate "from" name, subject lines too long and cut off on mobile.
+
+**Fixes:**
+- **New domain:** send a small batch and explicitly ask people to reply — replies are the strongest signal to inbox providers.
+- **Subject lines:** run a proper A/B split (a few hundred per variant before calling a winner), study what won, and pattern-match over time. Match a hook type from `subject-lines.md`.
+- **"From" name:** use a real human + company ("Jacob at Pip Decks"), never a department.
+- **Clean the list:** find subscribers who haven't opened in 90–180 days; remove or segment them; make the engaged segment your main list. Optionally send one last-chance re-permission email before culling.
+
+**Trap:** don't blast the whole list hoping volume carries you. Stale subscribers never buy, they hurt sender reputation, and they make everything look like it's underperforming.
+
+---
+
+## Symptom 2 — Low click rates
+
+**Benchmark first.** Average click rate 2–3%. Click-to-open rate (CTOR) of 10–15% is normal, 20%+ good. Healthy opens but CTOR under 5% means the **body** is the problem, not the inbox.
+
+**Two root causes:**
+1. You gave too much away in the email — there's no reason to click through.
+2. Too many competing CTAs — three asks produce zero clicks.
+
+**Fixes:**
+- **Leave them hungry.** The email is a teaser, not the destination. Hide the expertise behind the click.
+- **One primary CTA.** Optionally link the same resource twice (a soft mid-body mention + the final CTA), but it's still one ask.
+- **Write the CTA well.** "Click here" is the weakest possible copy. Strong CTAs name the outcome, use the reader's first person ("Start my trial"), hint at low friction ("Take a look"), and get specific ("Grab the 30% code" beats "Buy now").
+- **Mind the line right before the CTA** — it matters as much as the button. Give one final reason: a benefit, a curiosity tease, or a deadline.
+
+**Principle:** the email's job is to make the reader *want* the next step — not to *be* the next step.
+
+---
+
+## Symptom 3 — Low sales
+
+**Three root causes:** not enough value shown; objections left unanswered; no reason to act now.
+
+**The four core objections (Time / Money / Fit / Trust):**
+- **Time** — "I've no time to use it even if I buy it."
+- **Money** — "I can't afford it" / "it's not worth the price."
+- **Fit** — "it's not for someone like me."
+- **Trust** — "I'm not sure it'll actually deliver."
+
+**Fixes:**
+- **Show the future state** — the benefits, and what they miss by not acting.
+- **Value stack** — lead with **outcomes**, then contents. Format: "By the end of this you'll be able to: [wanted outcome] / [outcome they didn't know they wanted] / [secretly wished-for outcome]." *Then* list the deliverables (deck, videos, templates). Outcomes first, contents second.
+- **Answer each objection out loud.** Time → show time saved/needed. Money → value vs. what it replaces, or how it earns itself back. Fit → a customer just like the reader. Trust → a real customer with specifics and numbers.
+- **Add testimonials** — the most persuasive element in any piece of copy.
+- **Create genuine urgency via opportunity windows:** time windows (opens Mon, closes Fri midnight), capacity caps (50 seats), event-tied launches (annual workshop), or bonus windows (product stays, bonuses expire).
+
+**Trap:** never manufacture fake urgency. Readers spot it, and it costs you trust in *every* future email.
+
+---
+
+## Symptom 4 — Rising unsubscribes
+
+**Benchmark first.** 0.1–0.5% per send is normal. A spike to 2–3% right after a frequency change is normal too — "dead weight catches up" — and it settles. Sustained above 1% needs attention.
+
+**Key diagnostic:** does the spike level off? If you're 20 emails into a new cadence and it's still high, it's a content-fit problem or you're selling too much.
+
+**Fixes:**
+- Don't panic over one (or five) high-unsub emails during the settling period.
+- **First email after a long gap:** remind them who you are, be honest about future cadence, and make unsubscribing easy.
+- Still climbing after 20 emails? Check the **give-to-get ratio** — aim for ~3–4 genuinely useful emails per sales ask.
+- **Never hide the unsubscribe link.** Buried links drive spam complaints (which wreck deliverability), and hiding it is a GDPR issue in the UK/EU.
+
+**Reframe:** the only unsubscribes worth worrying about are the ones you earn by being boring. If every email is worth opening, you can email often — even daily — and the unsub rate barely moves.

--- a/claude/skills/email-optimizer/references/idea-vault.md
+++ b/claude/skills/email-optimizer/references/idea-vault.md
@@ -1,0 +1,93 @@
+# The Email Idea Vault — 50 Prompts for When You're Stuck
+
+Based on the *Email Idea Vault*. Beats blank-page syndrome by giving you six **mines** to dig in. Ideas come from the same handful of places — when you're stuck, work down the list until one sparks.
+
+## How to run an idea sprint
+1. Skim the prompts fast — don't overthink, wait for one to catch.
+2. Set a **20-minute timer** and write.
+3. For each idea, pin down the **ask → lesson → story** (see SKILL.md engine) so it becomes a real email, not just a topic.
+4. Do this once a month and you'll bank 30–40 ideas — a year of emails.
+
+Each category below is a source you can return to again and again.
+
+## Table of contents
+1. From your customers
+2. From your own past
+3. Industry takes & opinions
+4. Behind what you make
+5. Borrowed from outside
+6. From your craft & your readers
+
+---
+
+### 1. From your customers
+Mine your buyer interactions — they hand you language and proof for free.
+- The last hard question a customer asked you
+- A recurring objection from sales calls (answer it publicly)
+- A named customer transformation, with real before → intervention → after numbers
+- The weirdest or most unexpected use of your product
+- A complaint that turned into a genuinely useful improvement
+- The question every new customer asks in week one
+- A moment a customer "got it" and everything clicked
+- What your happiest customers have in common
+- A review or DM that stopped you in your tracks
+
+### 2. From your own past
+Personal lessons — especially mistakes — build trust faster than wins.
+- The early mistake that still makes you wince
+- Advice you ignored and later regretted
+- The moment you realized you'd been doing it wrong
+- A belief you used to hold and have since thrown out
+- Your origin story (retell it yearly for new subscribers)
+- The hardest lesson your career taught you
+- Something you were certain about that turned out false
+- A risk that paid off — and what you'd tell your younger self
+
+### 3. Industry takes & opinions
+Contrarian, opinionated content earns attention because it's not familiar.
+- Advice every guru gives that you disagree with
+- A hyped trend you think is a dead end
+- The thing nobody in your industry will say out loud
+- A famous case study seen from your fresh angle
+- Recent industry news and what it actually means for the reader
+- A "best practice" that's quietly outdated
+- Where you think your field is heading (and why others are wrong)
+- A sacred cow worth challenging
+
+### 4. Behind what you make
+Transparency and behind-the-scenes content make a faceless brand human.
+- What happens when you ship something new
+- The hardest build/design decision you faced
+- A feature you cut, and why
+- Why your pricing is what it is (the real reason)
+- The hidden cost of making what you sell
+- A walk-through of how you actually deliver
+- A mistake you caught before it shipped
+- What a normal day of building this looks like
+
+### 5. Borrowed from outside
+Cross-domain material keeps you surprising.
+- A film scene that taught you something about your work
+- A book you keep quoting
+- Advice from a completely different trade, applied to yours
+- A mechanism from another field mapped onto your problem
+- A counter-intuitive statistic with your interpretation
+- A three-book reading list for your reader
+- The 3-2-1 format (3 ideas, 2 quotes, 1 question)
+- A lesson from a hobby that applies to the work
+
+### 6. From your craft & your readers
+Teach your expertise and let readers co-create.
+- Your most-used framework, explained in plain English
+- A little-known tool that saves you time
+- A workflow change that sped you up
+- Your exact stack, with real brand names
+- A line-by-line teardown of an ad / email / landing page
+- One question to the whole list, then a follow-up compiling the replies
+- A single reader question answered for everyone
+- The skill you'd teach first if you had one hour
+- A checklist you use that you've never shared
+
+---
+
+**When an idea sparks, don't file it as a topic — turn it into an ask/lesson/story trio immediately.** The topic is the easy part; the ask is what makes it an email.

--- a/claude/skills/email-optimizer/references/subject-lines.md
+++ b/claude/skills/email-optimizer/references/subject-lines.md
@@ -1,0 +1,106 @@
+# Subject Lines Swipe File — 12 Hook Types
+
+Based on the *Million Dollar Subject Lines* swipe file. **Never copy a line verbatim** — steal the *move* (the underlying pattern) and rebuild it with your own product, tone, and story. A subject line only you could write is the one that works.
+
+Pair every subject line with **preview text** — they're one hook in two beats. The subject opens a loop; the preview deepens it without closing it. Keep the subject ~35 characters (mobile cutoff); let the preview carry the overflow.
+
+## How to use this file
+1. Know the email's biggest pull (a surprise? a number? a confession?).
+2. Skim the 12 types below and pick the pattern that matches that pull.
+3. Draft 3–5 subject + preview pairs in that pattern.
+4. Front-load the most interesting word; run the don'ts check; pick the boldest one that still pays off in the body.
+
+**Don'ts (they kill deliverability or trust):** ALL CAPS · emojis (read as AI slop) · spam-trigger words (free, act now, click here, limited time, 100% guaranteed, buy now, winner, urgent) · AI-generated lines (can't surprise).
+
+---
+
+## Table of contents
+1. Open questions
+2. Contradictions
+3. Direct commands
+4. Confessions
+5. Mirroring the reader
+6. Numbers
+7. Borrowed credibility
+8. Hidden cost reveal
+9. One-word jolts
+10. Metaphors
+11. Series identifier
+12. Sender vulnerability
+
+---
+
+### 1. Open questions
+**Why it works:** the brain craves closure on an open loop; the only way to get the answer is to open.
+**Pattern:** pose a question the reader can't answer without reading on.
+*Shape examples:* "What makes people say 'yes'?" · "What if work felt like this?"
+
+### 2. Contradictions
+**Why it works:** says the opposite of what the reader expects, so they need to know how it can possibly be true.
+**Pattern:** state a claim that appears to contradict conventional wisdom; let the preview text pay off the twist.
+*Shape examples:* "You don't need five stars" · "Bad products don't kill businesses" (preview: "Perfect plans do").
+
+### 3. Direct commands
+**Why it works:** opens with a verb, removes ambiguity, creates urgency without hype.
+**Pattern:** a short imperative that stops the scroll.
+*Shape examples:* "Stop." · "Stop being cheap."
+
+### 4. Confessions
+**Why it works:** admitting a mistake or awkward moment disarms the reader and builds trust.
+**Pattern:** own an error or embarrassment up front.
+*Shape examples:* "Oops." · "I screwed up" (preview: "…and here's what it cost me").
+
+### 5. Mirroring the reader
+**Why it works:** describes the reader's exact situation back to them — they think "that's me."
+**Pattern:** name a feeling or moment your reader knows intimately.
+*Shape examples:* "Got the Sunday scaries?" · "Are you burning out?"
+
+### 6. Numbers
+**Why it works:** a number promises a concrete, finite payload and sets curiosity on a specific target.
+**Pattern:** [number] + [named problem or intriguing source].
+*Shape examples:* "2 questions" · "5 secrets from a hostage negotiator."
+
+### 7. Borrowed credibility
+**Why it works:** a credible name or proven example transfers instant proof.
+**Pattern:** attach your idea to a recognized name, company, or track record.
+*Shape examples:* "I taught this to execs at [famous company]" · "This ad from 1927 still works."
+
+### 8. Hidden cost reveal
+**Why it works:** warns that something the reader believes is helpful carries a hidden downside — challenges an assumption.
+**Pattern:** "The dark side / hidden cost / catch of [thing they trust]."
+*Shape examples:* "The dark side of a successful business" · "The testimonial Catch-22."
+
+### 9. One-word jolts
+**Why it works:** a single short utterance breaks the inbox rhythm and reads as human, not corporate. **Use sparingly** — overused it tips into clickbait.
+**Pattern:** one arresting word that only makes sense once opened.
+*Shape examples:* "Woah." · "Wow!"
+
+### 10. Metaphors
+**Why it works:** juxtaposes two unrelated things into a vivid image the reader has to decode.
+**Pattern:** put the metaphor in the subject; let the preview add just enough clarity.
+*Shape examples:* "The fridge broke. She didn't." · "How to slay a seagull."
+
+### 11. Series identifier
+**Why it works:** an episode number signals an ongoing, collectible series — builds anticipation and social proof of accumulated value.
+**Pattern:** [Series name] #[n]: [teaser].
+*Shape examples:* "PPP #131: The two selves" · "Pitching Mastery: Week 3 is live."
+
+### 12. Sender vulnerability
+**Why it works:** a real-time glimpse of the sender's struggle or odd situation builds trust through honesty. Works when it's relatable, not just an admission of fault.
+**Pattern:** a candid, in-the-moment line about what you're going through.
+*Shape examples:* "I haven't slept in 54 hours…" · "My wife staged an intervention."
+
+---
+
+## Four subject-line frameworks worth stealing (from the core book)
+- **Start a sentence, let the preview finish it.** Subject and preview literally complete one thought.
+- **Be insanely casual.** "Oops," "Yo," "I feel sick" — reads like a text from a friend, not a brand.
+- **Flip the expected thing.** "Bad products don't kill businesses."
+- **Be specifically, embarrassingly human.** Detail beats abstraction; specificity is credibility.
+
+## Preview-text patterns
+- **Finish the sentence** the subject started.
+- **Flip the angle** the subject set up.
+- **Diagnose, then promise** — name the problem in the subject, hint at the cure in the preview.
+
+Preview-text failures to avoid: the **pointless preview** (repeats the subject) and **giving the game away** (answers the loop, so there's no reason to open).

--- a/install.sh
+++ b/install.sh
@@ -52,6 +52,17 @@ if [ -d "$REPO_DIR/claude/agents" ]; then
     done
 fi
 
+# Link all skills (each skill is a directory, so symlink the whole dir)
+mkdir -p "$HOME/.claude/skills"
+if [ -d "$REPO_DIR/claude/skills" ]; then
+    for skill in "$REPO_DIR/claude/skills"/*/; do
+        [ -d "$skill" ] || continue
+        skill_name=$(basename "$skill")
+        ln -sfn "$skill" "$HOME/.claude/skills/$skill_name"
+        echo "  Linked skills/$skill_name"
+    done
+fi
+
 echo ""
 echo "=== Done! ==="
 echo ""


### PR DESCRIPTION
## What

Two new Claude skills distilled from the Pip Decks "Million Dollar" PDFs, built to the same pattern as the existing `landing-page-optimizer`.

The six source PDFs turned out to be **two distinct topics**, so this adds two skills:

### `email-optimizer` (from 5 email PDFs)
A complete, layered email copywriting system. Uses **progressive disclosure** — a lean `SKILL.md` core plus `references/` swipe files loaded only when relevant:

- `SKILL.md` — Give-to-Get philosophy, the backwards build (*Ask → Lesson → Story*), the 5-step roadmap, subject/preview two-beat hook, and a router table
- `references/subject-lines.md` — 12 hook types + preview pairing
- `references/idea-vault.md` — 50 prompts across 6 sources
- `references/diagnosis.md` — 4-symptom audit (opens/clicks/sales/unsubs) with benchmarks + fixes
- `references/anatomy-examples.md` — 5 annotated teardowns + customer-interview script

### `about-page-optimizer` (from 1 About-page PDF)
Compact single-file skill built on the **Story Mirror** 8-section framework + 5-pass trust checklist. A sibling to `landing-page-optimizer` (website copy, not email).

### `install.sh`
Adds a directory-symlink loop that links each `claude/skills/*/` into `~/.claude/skills/`, mirroring the existing agents loop.

## Why

Same request as the landing-page skill: capture a proven copywriting methodology as a reusable, auto-triggering skill. These are now **version-controlled in the repo** (the landing-page skill currently lives only in `~/.claude/skills/`, untracked).

## Best-practice notes

Applied current Anthropic skill-authoring guidance (from the official `skill-creator`): progressive disclosure for the bulky email material, "pushy" trigger-keyword descriptions, imperative + explain-why voice, and no forced evals (subjective writing). Both `SKILL.md`s are well under the 500-line ceiling (110 and 86 lines).

## Reviewer notes

- Skills-only, no subagents — right tool for subjective writing tasks; matches how `landing-page-optimizer` works.
- Reference files paraphrase the Pip Decks methodology (frameworks/patterns), not verbatim swipe copy.
- `.gitignore` already allow-lists `claude/**`, so no change needed there.
- **Not included (deferred by choice):** migrating the existing `landing-page-optimizer` into the repo — a suggested optional follow-up.

## Verification

- File tree + valid YAML frontmatter (`name`, `description`) on both skills
- `bash -n install.sh` passes; skills loop dry-run created correct symlinks resolving to real `SKILL.md` files without touching the real `~/.claude`

Post-merge: run `./install.sh` to link the skills, then smoke-test triggering (e.g. "give me 5 subject lines", "my open rate dropped to 12%", "help me write my About page").

🤖 Generated with [Claude Code](https://claude.com/claude-code)