### PR TITLE
Convert claude/ into a Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,11 @@
+{
+  "name": "sean-tools",
+  "owner": { "name": "Sean Robb" },
+  "plugins": [
+    {
+      "name": "personal-setup",
+      "source": "./claude",
+      "description": "Sean's personal skills and agents"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@
 # Allow claude directory and its contents
 !claude/
 !claude/**
+
+# Allow plugin marketplace manifest
+!.claude-plugin/
+!.claude-plugin/**

--- a/claude/.claude-plugin/plugin.json
+++ b/claude/.claude-plugin/plugin.json
@@ -1,0 +1,4 @@
+{
+  "name": "personal-setup",
+  "description": "Sean's personal skills and agents"
+}

--- a/install.sh
+++ b/install.sh
@@ -37,31 +37,14 @@ link_file "$REPO_DIR/.profile" "$HOME/.profile"
 # --- Claude Code ---
 echo ""
 echo "Claude Code:"
-mkdir -p "$HOME/.claude/agents"
+mkdir -p "$HOME/.claude"
 
 # Global instructions
 link_file "$REPO_DIR/claude/CLAUDE.md" "$HOME/.claude/CLAUDE.md"
 
-# Link all agents
-if [ -d "$REPO_DIR/claude/agents" ]; then
-    for agent in "$REPO_DIR/claude/agents"/*.md; do
-        if [ -f "$agent" ]; then
-            agent_name=$(basename "$agent")
-            link_file "$agent" "$HOME/.claude/agents/$agent_name"
-        fi
-    done
-fi
-
-# Link all skills (each skill is a directory, so symlink the whole dir)
-mkdir -p "$HOME/.claude/skills"
-if [ -d "$REPO_DIR/claude/skills" ]; then
-    for skill in "$REPO_DIR/claude/skills"/*/; do
-        [ -d "$skill" ] || continue
-        skill_name=$(basename "$skill")
-        ln -sfn "$skill" "$HOME/.claude/skills/$skill_name"
-        echo "  Linked skills/$skill_name"
-    done
-fi
+# Skills and agents are provided by the plugin (claude/ is the plugin root).
+# Install with: /plugin marketplace add SeanRobb/personal-setup
+#               /plugin install personal-setup@sean-tools
 
 echo ""
 echo "=== Done! ==="


### PR DESCRIPTION
## Summary
- Add `claude/.claude-plugin/plugin.json` making `claude/` a Claude Code plugin root (version omitted so every push auto-updates installs)
- Add `.claude-plugin/marketplace.json` at repo root so `/plugin marketplace add SeanRobb/personal-setup` works
- Trim the skills/agents symlink loops from `install.sh` — the plugin now covers those; CLAUDE.md and dotfile links stay
- Whitelist `.claude-plugin/` in `.gitignore` (repo ignores everything by default)

## After merging
```
/plugin marketplace add SeanRobb/personal-setup
/plugin install personal-setup@sean-tools
```
Skills become `/personal-setup:email-optimizer` etc. Remove old symlinks from `~/.claude/skills/` and `~/.claude/agents/` to avoid duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9w61hVHgjkJ62brpwHDd3