### PR TITLE
Add sean-voice skill to the personal-setup plugin

### DIFF
--- a/claude/skills/sean-voice/README.md
+++ b/claude/skills/sean-voice/README.md
@@ -1,0 +1,48 @@
+# Sean Voice Skill
+
+Sean Robb's core writing voice — the shared, medium-agnostic layer applied to any prose published in his name. Originated as the `workhoodie-voice` skill in the workhoodie.com repo, generalized here for use across all projects.
+
+## Overview
+
+Keeps AI-drafted or AI-edited writing sounding like Sean instead of like a model. Covers voice principles, anti-patterns, a catalog of AI voice tells with before/after examples, and a specificity rule. Medium-specific style guides (blog long-form, LinkedIn social) live in their own project docs and build on top of this.
+
+## Automatic Triggers
+
+The skill activates on terms like: my voice, voice check, de-AI, AI tells, sound like me, write this as me, blog post, linkedin post, personal site copy.
+
+## Core Principles
+
+- **Conversational fragments** — written the way it'd be said out loud
+- **Self-questioning** — show the thinking as it happened, don't just narrate outcomes
+- **Connective tissue** — sentences breathe into each other; no false staccato rhythm
+- **Quieter confidence** — declarative statements over rallying cries
+- **Causal anchoring** — structural claims anchored in something concrete and checkable
+- **Specificity** — the precise term over the impressive-sounding one
+
+Plus a catalog of AI tells to strip: stock transitions, setup-and-flip pivots, editorial signposts, punchy triplets, decade forecasts, parallel negation, mic-drop closers, and more.
+
+## Structure
+
+```
+sean-voice/
+├── SKILL.md    # Voice principles + anti-patterns + AI tells catalog
+└── README.md   # This file
+```
+
+Single-file skill — the voice guide is compact enough to keep in one place.
+
+## Example Prompts
+
+- "Write this LinkedIn post in my voice"
+- "De-AI this draft"
+- "Does this blog post sound like me?"
+- "Edit this email so it doesn't read as generated"
+
+## Installation
+
+Provided by the `personal-setup` plugin (`claude/` is the plugin root). Install with `/plugin marketplace add SeanRobb/personal-setup` then `/plugin install personal-setup@sean-tools`.
+
+## Related skills
+
+- `email-optimizer` — email structure and strategy; this skill governs how the words sound.
+- `about-page-optimizer` — About page framework; same relationship.

--- a/claude/skills/sean-voice/SKILL.md
+++ b/claude/skills/sean-voice/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: sean-voice
+description: |
+  Sean Robb's core writing voice. Use when writing or editing any prose in Sean's name — blog posts, LinkedIn or social posts, emails, website copy, READMEs, About pages — to keep it in his voice and catch AI tells. Covers voice principles, what to avoid, AI voice tells, and specificity. Medium-specific guidance (blog structure, social patterns) lives in separate style docs that build on this.
+  MANDATORY TRIGGERS: my voice, sean's voice, voice check, de-AI, AI tells, sound like me, write this as me, blog post, linkedin post, personal site copy
+---
+
+# Sean's Core Voice
+
+Sean Robb's voice. This is the shared, medium-agnostic layer. Apply it to any writing
+published in Sean's name. Medium-specific style guides (blog long-form, LinkedIn social)
+build on top of this.
+
+---
+
+## Voice
+
+**Conversational fragments** — the way you'd say it out loud to someone, not how you'd write a LinkedIn post. Fragments are fine when they feel natural, not when they feel stylized.
+
+**Self-questioning** — process out loud. Don't just narrate what happened, show the thinking as it happened.
+- ✅ "I kept telling myself that was fine."
+- ✅ "I started asking myself whether that was just the price of doing meaningful work."
+- ✅ "I held that belief for longer than I should have."
+- ❌ "It was the wrong choice." (tells, doesn't show)
+
+**Connective tissue** — sentences breathe into each other using and, but, because. Avoid hard stops that create false rhythm.
+
+**Quieter confidence** — declarative statements over rallying cries.
+- ✅ "Hoodies are for serious work."
+- ❌ "Hoodie over suit. Always."
+
+**Causal anchoring** — when making a structural claim ("AI works like engineers"), anchor it in something concrete the reader can look up: a date, a product ship, an event. The reader should land on "of course" rather than "let me argue this."
+- ❌ "AI tools were designed around the formats engineers use."
+- ✅ "GitHub Copilot shipped in 2021. AI was built by engineers, for engineers."
+
+---
+
+## What to Avoid
+
+**Em dashes** — restructure the sentence instead. If you find yourself reaching for one, the sentence probably needs rewriting. **Target: 0–2 in body prose.** Em dashes creep back during iteration — do a final count before shipping.
+
+**Hedging adjective stacks** — "really just", "actually different", "genuinely useful", "far less glamorous and far stickier". Strip the hedges; the noun does the work.
+- ❌ "The lock-in is moving down the stack, onto something far less glamorous and far stickier."
+- ✅ "The lock-in is moving down the stack to something stickier."
+
+**Punchy triplets** — "Real work. Real stakes. Real impact." reads as performative. Merge them or cut one.
+- ❌ "Real work. Real stakes. Real complexity."
+- ✅ "Real work with real stakes."
+
+**On-the-nose writing** — if the section header already says it, don't repeat it in the first line of that section.
+
+**Preachy/editorial** — don't tell the reader what to think. Show the experience and let them draw the conclusion.
+- ❌ "I don't think enterprise companies believe that's possible."
+- ✅ Let the two burnout story make that point without stating it.
+
+**Consecutive same-opener sentences** — three sentences starting with "You can" or "I" in a row creates unwanted rhythm. Vary the structure.
+
+**Monotone feature lists** — six bold-lead paragraphs with the same structure ("**Feature.** Explanation.") reads like marketing copy, not Sean. Vary the sentence structure even when listing capabilities. Start some with "It does X", some with "The X tool", some with "And it can".
+
+---
+
+## AI Voice Tells
+
+When drafting or editing with AI, watch for these patterns that make the writing sound generated instead of written.
+
+**Stock transitions** — "And it wasn't just X, it was Y" is a hallmark AI pivot. Rewrite or cut the transition entirely.
+- ❌ "And it wasn't just faster, it was more accurate."
+- ✅ "It was also more accurate." or just start the next sentence.
+
+**Setup-and-flip pivots** — "That's not [X]. It's [Y]." constructions are a slower cousin of the stock transition. Same AI smell. Cut the setup and let Y land directly.
+- ❌ "That's not a quirk of how I set things up. It's how AI tools are built."
+- ✅ "AI tools are built around the formats engineers use."
+
+**Editorial signposts** — phrases that announce a conclusion instead of delivering one. "The practical consequence:", "what this means is", "in other words", "the takeaway here". Cut and let the next sentence carry it.
+- ❌ "The practical consequence: most of what people call 'working effectively with AI' is just moving work onto the substrate."
+- ✅ "Most of what people call 'working effectively with AI' is just moving work onto the substrate."
+
+**Decade forecasts** — "the next ten years", "by 2030", "a couple of years from now". Pundit-speak. Anchor in what's true now or in the recent past instead.
+- ❌ "The next ten years of productivity gains won't come from better apps."
+- ✅ Drop the forecast; describe what's already changing.
+
+**Abstract noun constructions** — "designed for X showing work to other X", "built around the assumption that", "shaped around" — turning concrete observations into editorial abstractions. Tighten to what actually happens.
+- ❌ "Office formats were designed for humans showing work to other humans."
+- ✅ "Office formats were built to be read by humans only."
+
+**Borrowed historical analogies for credibility** — "the way SaaS in 2012 looked by 2014" / VC-deck comparisons. Sean writes from his own experience, not historical templates.
+- ❌ "The companies that figure this out will look, a couple of years from now, the way the SaaS winners of 2012 looked by 2014."
+- ✅ Observe what you've actually seen instead.
+
+**Vague realizations** — "I realized something had shifted" says nothing. Sean would describe what actually happened.
+- ❌ "I realized something had shifted."
+- ✅ "I just sat there."
+
+**Inline definitions** — "MCP, Model Context Protocol, lets you..." reads like a Wikipedia aside. Link it or explain it naturally.
+- ❌ "MCP, Model Context Protocol, lets you give Claude Code tools."
+- ✅ "[MCP](https://modelcontextprotocol.io/) lets you give Claude Code custom tools."
+
+**Imperative advice to the reader** — "Give Claude Code the ability to see, not just act" is preachy. Sean shows through his own experience, not commands.
+- ❌ "Give Claude Code the ability to see, not just act."
+- ✅ "The screenshot tool changed the dynamic more than start and stop did."
+
+**Overly confident declarations** — "That's all it took to get out of Claude Code's way" is a mic-drop that Sean wouldn't write. He'd just move on.
+- ❌ "That's all it took to get out of Claude Code's way."
+- ✅ "That's it."
+
+**Repeated "couldn't" / "wouldn't" / "doesn't" triplets** — AI loves parallel negation. Merge with "or" for connective tissue.
+- ❌ "It couldn't see the app, couldn't read the console, couldn't look at the logs."
+- ✅ "It couldn't see the app or read the console or look at the logs."
+
+**Title clickbait** — "10x" and similar multiplier claims are bro-marketing, not Sean's voice. Frame around the actual experience.
+- ❌ "How This Custom MCP Server 10x'd My Development Speed"
+- ✅ "How I Move Faster With Claude Code and a Custom MCP"
+
+---
+
+## Specificity
+
+Specific beats impressive. Use the precise term, not the impressive-sounding one.
+- ✅ "bear market" not "market contraction"
+- ✅ "37signals" not "37 Signals" (one word, their actual brand)
+- ✅ Real details over credentials where possible
+
+---
+
+## Context Layers
+
+This is the core layer. Project-specific context stacks on top:
+
+- **WorkHoodie** — the thesis is *casual and competent without the grind*: serious, technically rigorous work without Fortune 500 bureaucracy or the VC grind machine. Indie and bootstrapped, not amateur. Direct, not an agency. Limited by design, deep over wide.
+- Other projects define their own positioning docs; this voice applies either way.


### PR DESCRIPTION
## Summary
- Pulls the `workhoodie-voice` skill from workhoodie.com into this plugin as `sean-voice`
- Generalizes it from WorkHoodie-branded to Sean's personal voice, so it applies to any prose in his name (blog, LinkedIn, emails, site copy, READMEs)
- Voice principles and the AI-tells catalog carry over unchanged; the WorkHoodie thesis moves to a small "Context Layers" section at the end
- Adds a README matching the format of the other plugin skills; no plugin.json changes needed since skills are auto-discovered from `claude/skills/`

## Test plan
- [ ] Install/reload the plugin and confirm `personal-setup:sean-voice` appears in the skills list
- [ ] Ask for a "voice check" or "write this as me" and confirm the skill triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9w61hVHgjkJ62brpwHDd3