### PR TITLE
Resolve options-goal's base skill via sibling path for plugin installs

### DIFF
--- a/claude/skills/options-goal/SKILL.md
+++ b/claude/skills/options-goal/SKILL.md
@@ -13,7 +13,10 @@ champion.
 
 ## Composition contract
 
-**FIRST ACTION: read `~/.claude/skills/options/SKILL.md`.** Every
+**FIRST ACTION: read the base options skill's SKILL.md** — it ships as
+this skill's sibling, so resolve `../options/SKILL.md` relative to this
+file (works in the plugin cache and any repo checkout); fall back to
+`~/.claude/skills/options/SKILL.md` for a standalone install. Every
 scaffolding convention comes from it verbatim and stays exactly compatible:
 framework detection, target resolution, `manifest.json`, `mocks.ts`,
 self-contained `OptionN.tsx` components, the grid index + `[id]` detail


### PR DESCRIPTION
## Summary

Follow-up to #12: options-goal's FIRST ACTION pointed at `~/.claude/skills/options/SKILL.md`, which only exists via the dev symlink. Now that both skills ship in the personal-setup plugin (#11), the base skill is resolved as the sibling directory `../options/SKILL.md` relative to the skill file — valid in the plugin cache and any repo checkout — with the `~/.claude` path kept as a standalone-install fallback.

One-line doc change, no behavior otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LuRwkVjEGzV7XVVDC96o6t